### PR TITLE
Collapseした枝でRerootするとクラッシュする問題の修正

### DIFF
--- a/src/TreeMage.Core.Test/Trees/TreeTest.cs
+++ b/src/TreeMage.Core.Test/Trees/TreeTest.cs
@@ -340,6 +340,78 @@ namespace TreeMage.Core.Trees
         }
 
         [Fact]
+        public void Reroot_AsPositive_WithNonRootOnCollapsed_AsUnrootedToUnrooted()
+        {
+            this.cladeBB.Style.Collapsed = true;
+            tree.Reroot(this.cladeBB, false);
+
+            Clade root = tree.Root;
+            CheckBipartition(tree, root, double.NaN, null, 3, null);
+            Assert.False(root.Style.Collapsed);
+
+            Clade cladeBB = root.ChildrenInternal[0];
+            CheckBipartition(tree, cladeBB, 2, "100/100", 2, root);
+            Assert.True(cladeBB.Style.Collapsed);
+
+            Clade cladeB = cladeBB.ChildrenInternal[0];
+            CheckBipartition(tree, cladeB, 2, "30/45", 2, cladeBB);
+            Assert.False(cladeB.Style.Collapsed);
+
+            Clade leafA = cladeB.ChildrenInternal[0];
+            CheckLeaf(tree, leafA, 2, "A", cladeB);
+            Clade leafC = cladeB.ChildrenInternal[1];
+            CheckLeaf(tree, leafC, 1, "C", cladeB);
+
+            Clade cladeBA = cladeBB.ChildrenInternal[1];
+            CheckBipartition(tree, cladeBA, 1, "20/30", 2, cladeBB);
+
+            Clade leafBAA = cladeBA.ChildrenInternal[0];
+            CheckLeaf(tree, leafBAA, 5, "BAA", cladeBA);
+            Clade leafBAB = cladeBA.ChildrenInternal[1];
+            CheckLeaf(tree, leafBAB, 3, "BAB", cladeBA);
+
+            Clade cladeBBA = root.ChildrenInternal[1];
+            CheckBipartition(tree, cladeBBA, 1, "85/95", 2, root);
+
+            Clade leafBBAA = cladeBBA.ChildrenInternal[0];
+            CheckLeaf(tree, leafBBAA, 2, "BBAA", cladeBBA);
+            Clade leafBBAB = cladeBBA.ChildrenInternal[1];
+            CheckLeaf(tree, leafBBAB, 1, "BBAB", cladeBBA);
+
+            Clade leafBBB = root.ChildrenInternal[2];
+            CheckLeaf(tree, leafBBB, 3, "BBB", root);
+
+            static void CheckBipartition(Tree tree, Clade clade, double branchLength, string? supports, int childCount, Clade? parent)
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.Same(tree, clade.Tree);
+                    if (clade.IsRoot) Assert.Same(tree, clade.TreeInternal);
+                    else Assert.Null(clade.TreeInternal);
+                    Assert.Equal(branchLength, clade.BranchLength);
+                    Assert.Equal(supports, clade.Supports);
+                    Assert.Null(clade.Taxon);
+                    Assert.Equal(childCount, clade.ChildrenInternal.Count);
+                    Assert.Equal(parent, clade.Parent);
+                });
+            }
+
+            static void CheckLeaf(Tree tree, Clade clade, double branchLength, string? taxon, Clade parent)
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.Same(tree, clade.Tree);
+                    Assert.Null(clade.TreeInternal);
+                    Assert.Equal(branchLength, clade.BranchLength);
+                    Assert.Null(clade.Supports);
+                    Assert.Equal(taxon, clade.Taxon);
+                    Assert.Empty(clade.ChildrenInternal);
+                    Assert.Equal(parent, clade.Parent);
+                });
+            }
+        }
+
+        [Fact]
         public void Reroot_AsPositive_WithNonRoot_AsUnrootedToRooted()
         {
             tree.Reroot(cladeBB, true);

--- a/src/TreeMage.Core/Trees/Tree.cs
+++ b/src/TreeMage.Core/Trees/Tree.cs
@@ -153,6 +153,7 @@ namespace TreeMage.Core.Trees
                     Clade rootChild1 = CreateClade(clade);
                     Root.TreeInternal = null;
                     rootChild1.BranchLength /= 2;
+                    rootChild1.Style.Collapsed = false;
 
                     var rootChild2 = new Clade()
                     {
@@ -180,6 +181,7 @@ namespace TreeMage.Core.Trees
                 clade.Parent = null;
                 clade.BranchLength = double.NaN;
                 clade.Supports = null;
+                clade.Style.Collapsed = false;
                 Root = clade;
                 Root.TreeInternal = this;
             }

--- a/src/TreeMage/Components/Shared/TreeView.razor.cs
+++ b/src/TreeMage/Components/Shared/TreeView.razor.cs
@@ -58,7 +58,7 @@ namespace TreeMage.Components.Shared
                          stroke-width: {tree.Style.BranchThickness}px;
                      }}
 
-                     .collapsed-rectangle {{
+                     .collapsed-triangle {{
                          fill: none;
                          stroke-width: {tree.Style.BranchThickness}px;
                      }}
@@ -109,13 +109,13 @@ namespace TreeMage.Components.Shared
         void ITreeDrawer.DrawCollapsedTriangle(TMPoint left, TMPoint rightTop, TMPoint rightBottom, TMColor stroke, int lineThickness, Clade target)
         {
             builder.OpenElement(++__elementCount, "path");
-            builder.AddAttribute(++__elementCount, "class", "collapsed-rectangle");
-            builder.AddAttribute(++__elementCount, "d",
-                $@"""M {left.X} {left.Y}
-                     L {rightTop.X} {rightTop.Y}
-                     L {rightBottom.X} {rightBottom.Y}
-                     L {left.X} {left.Y}
-                  """);
+            builder.AddAttribute(++__elementCount, "class", "collapsed-triangle");
+            builder.AddAttribute(++__elementCount, "d", $"""
+                                     M {left.X} {left.Y}
+                                     L {rightTop.X} {rightTop.Y}
+                                     L {rightBottom.X} {rightBottom.Y}
+                                     L {left.X} {left.Y}
+                """);
             builder.AddAttribute(++__elementCount, "stroke", stroke.Value);
             builder.CloseElement();
         }
@@ -280,6 +280,7 @@ namespace TreeMage.Components.Shared
             // Reroot用クリックエリア
             if (ViewModel.EditMode.Value is TreeEditMode.Reroot && !target.IsRoot)
             {
+                // Rooted
                 if (!target.IsLeaf && (tree.IsUnrooted || !target.Parent.IsRoot))
                 {
                     const double size = 5;
@@ -295,7 +296,8 @@ namespace TreeMage.Components.Shared
                     builder.CloseElement();
                 }
 
-                if (!target.IsLeaf)
+                // Unrooted
+                if (!target.GetIsExternal())
                 {
                     CladeId id = target.GetId(CladeIdSuffix.Node);
                     (double x, double y, double width, double height) = positionManager.CalcNodeDecorationRectangleArea(target);


### PR DESCRIPTION
#11 

- Unrootedな形にRerootできないように修正
- Reroot時にRootの折り畳み解除＆折り畳みが片方だけになるように調整
